### PR TITLE
Fix SRT parsing to use state machine

### DIFF
--- a/lib/captions/cue.rb
+++ b/lib/captions/cue.rb
@@ -14,12 +14,12 @@ module Captions
 
     # Creates a new Cue class
     # Each cue denotes a subtitle.
-    def initialize
+    def initialize(cue_number = nil)
       self.text = nil
       self.start_time = nil
       self.end_time = nil
       self.duration = nil
-      self.number = nil
+      self.number = cue_number
       self.properties = {}
     end
 

--- a/lib/captions/version.rb
+++ b/lib/captions/version.rb
@@ -1,3 +1,3 @@
 module Captions
-  VERSION = "1.3.0"
+  VERSION = "1.3.0.1"
 end

--- a/lib/captions/version.rb
+++ b/lib/captions/version.rb
@@ -1,3 +1,3 @@
 module Captions
-  VERSION = "1.3.0.1"
+  VERSION = "1.3.1"
 end


### PR DESCRIPTION
The current SRT parsing typically puts the first caption number into the text field because it only assumes it's a number after a blank line.  Most SRT files I have encountered start with the caption number on the very first line.   Switching to a state machine allows both the start of file and a blank line to properly detect the caption number.  It also enforces a more rigid number, time sequence, text, blank line formatting expectation.