### PR TITLE
Fix Center Alignment in VTT subs

### DIFF
--- a/captions.gemspec
+++ b/captions.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Subtitle Editor and Converter written in Ruby}
   spec.description   = %q{Subtitle Editor and Converter written in Ruby. Captions can read/modify/export subtitles from one format to another }
-  spec.homepage      = "https://github.com/navinre/captions"
+  spec.homepage      = "https://github.com/sahroshan/captions"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|

--- a/captions.gemspec
+++ b/captions.gemspec
@@ -6,8 +6,8 @@ require 'captions/version'
 Gem::Specification.new do |spec|
   spec.name          = "captions"
   spec.version       = Captions::VERSION
-  spec.authors       = ["navin"]
-  spec.email         = ["navin@amagi.com"]
+  spec.authors       = ["sahroshan"]
+  spec.email         = ["sahroshan@amagi.com"]
 
   spec.summary       = %q{Subtitle Editor and Converter written in Ruby}
   spec.description   = %q{Subtitle Editor and Converter written in Ruby. Captions can read/modify/export subtitles from one format to another }

--- a/lib/captions/formats/vtt.rb
+++ b/lib/captions/formats/vtt.rb
@@ -13,6 +13,7 @@ module Captions
     # Alignment Data
     ALIGNMENT_VALUES = {
       "middle" => "middle",
+      "center" => "middle",
       "left"   => "left",
       "right"  => "right",
       "start"  => "start",

--- a/lib/captions/version.rb
+++ b/lib/captions/version.rb
@@ -1,3 +1,3 @@
 module Captions
-  VERSION = "1.3.0"
+  VERSION = "1.3.5"
 end


### PR DESCRIPTION
VTT Files support center as styling format along with middle. This change support both of the styling formats during VTT parsing