### PR TITLE
support-center-vtt-alignment

### DIFF
--- a/lib/captions/formats/vtt.rb
+++ b/lib/captions/formats/vtt.rb
@@ -13,6 +13,7 @@ module Captions
     # Alignment Data
     ALIGNMENT_VALUES = {
       "middle" => "middle",
+      "center" => "middle",
       "left"   => "left",
       "right"  => "right",
       "start"  => "start",


### PR DESCRIPTION
VTT Files support center as styling format along with middle. This change support both of the styling formats during VTT parsing