### PR TITLE
Add cue indentifier

### DIFF
--- a/lib/captions/formats/vtt.rb
+++ b/lib/captions/formats/vtt.rb
@@ -7,6 +7,9 @@ module Captions
     # VTT file comments/style section
     VTT_METADATA = /^NOTE|^STYLE/
 
+    # The identifier is a name that identifies the cue.
+    CUE_IDENTIFIER = /^\d+((?!-->).)*$/
+
     # Auto Keyword used in Alignment
     AUTO_KEYWORD = "auto"
 
@@ -23,7 +26,6 @@ module Captions
     # Parse VTT file and update CueList
     def parse
       base_parser do
-        count = 1
         cue_count = 0
         meta_data_section = false
         cue = nil
@@ -32,6 +34,8 @@ module Captions
           line = line.strip
           if line.empty?
             meta_data_section = false
+          elsif !meta_data_section and is_cue_identifier?(line)
+            next
           elsif is_meta_data?(line)
             meta_data_section = true
           elsif is_time?(line)
@@ -83,6 +87,10 @@ module Captions
     # Check whether if its subtilte text or not
     def is_text?(text)
       !text.empty? and text.is_a?(String) and text != VTT_HEADER
+    end
+
+    def is_cue_identifier?(text)
+      text.match?(CUE_IDENTIFIER)
     end
 
     def set_properties(cue, properties)

--- a/spec/sample/test.vtt
+++ b/spec/sample/test.vtt
@@ -9,6 +9,7 @@ not be 100% accurate
 - I didn’t pay too close attention to
 when the cues should start or end.
 
+1
 00:00:04.080 --> 00:06.320 align:start position:21% line:90%,end
 I'm going to flip through this deck.
 
@@ -16,11 +17,14 @@ STYLE
 ::cue(#\31) { color: lime; }
 ::cue(#crédit\ de\ transcription) { color: red; }
 
+2
 00:06.400 --> 00:07.880 align:middle position:10% line:-1
 And I want you to see one card.
+32
 
 NOTE Comments
 
+3
 00:00:08.300 --> 00:00:09.400 align:middle line:90%,end
 Not this one. That's too obvious.
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/WebVTT_API
Example 9 - Common usage of identifiers

According to the above specification, added the handling for the cue identifiers.
Regular expression test is not enough, but most cases are satisfied.

